### PR TITLE
Add measure_all method (#48)

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -117,6 +117,22 @@ class Program(InstructionGroup):
         """
         return self.inst(MEASURE(qubit_index, classical_reg))
 
+    def measure_all(self, *qubit_reg_pairs):
+        """
+        Measures many qubits into their specified classical bits, in the order
+        they were entered.
+
+        :param Tuple qubit_reg_pairs: Tuples of qubit indices paired with classical bits.
+        :return: The Quil Program with the appropriate measure instructions appended, e.g.
+                  MEASURE 0 [1]
+                  MEASURE 1 [2]
+                  MEASURE 2 [3]
+        :rtype: Program
+        """
+        for qubit_index, classical_reg in qubit_reg_pairs:
+            self.inst(MEASURE(qubit_index, classical_reg))
+        return self
+
     def while_do(self, classical_reg, q_program):
         """
         While a classical register at index classical_reg is 1, loop q_program

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -202,6 +202,13 @@ def test_measurement_calls():
            MEASURE(0, Addr(1)))
     assert p.out() == 'MEASURE 0 [1]\n' * 2
 
+def test_measure_all():
+    p = Program()
+    p.measure_all((0, 0), (1, 1), (2, 3))
+    assert p.out() == 'MEASURE 0 [0]\n' \
+                      'MEASURE 1 [1]\n' \
+                      'MEASURE 2 [3]\n'
+
 
 def test_construction_syntax():
     p = Program().inst(X(0), Y(1), Z(0)).measure(0, 1)


### PR DESCRIPTION
Adds a method to measure a list of qubit-address pairs.

* added measure all

* specified measurement order

* specified measurement order again